### PR TITLE
fix: correct android makefile relative paths

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -6,9 +6,9 @@ set (CMAKE_CXX_STANDARD 11)
 # add directories to "include" search paths
 include_directories(
             ../cpp
-            ../node_modules/react-native/React
-            ../node_modules/react-native/React/Base
-            ../node_modules/react-native/ReactCommon/jsi
+            ../../../node_modules/react-native/React
+            ../../../node_modules/react-native/React/Base
+            ../../../node_modules/react-native/ReactCommon/jsi
 )
 
 # set the base libsodium build directory
@@ -33,7 +33,7 @@ set_target_properties( sodium PROPERTIES IMPORTED_LOCATION ${LIBSODIUM_BUILD_DIR
 # which will be built from the listed source files
 add_library(libsodium
   SHARED
-  ../node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp
+  ../../../node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp
   ../cpp/react-native-libsodium.cpp
   ../cpp/react-native-libsodium.h
   cpp-adapter.cpp


### PR DESCRIPTION
This fixes relative paths to `node_modules` in `CMakeLists.txt` that caused build failure on Android.

Closes https://github.com/serenity-kit/react-native-libsodium/issues/43 https://github.com/serenity-kit/react-native-libsodium/issues/45

Tested on following system:

```
CMake: 3.22.1

System:
    OS: macOS 13.4.1
    CPU: (8) arm64 Apple M1 Pro
    Memory: 116.34 MB / 16.00 GB
    Shell: 5.9 - /bin/zsh
  Binaries:
    Node: 18.16.0 - ~/.nvm/versions/node/v18.16.0/bin/node
    Yarn: 1.22.19 - /opt/homebrew/bin/yarn
    npm: 9.5.1 - ~/.nvm/versions/node/v18.16.0/bin/npm
    Watchman: 2023.08.14.00 - /opt/homebrew/bin/watchman
  Managers:
    CocoaPods: 1.12.1 - /opt/homebrew/bin/pod
  SDKs:
    iOS SDK:
      Platforms: DriverKit 22.4, iOS 16.4, macOS 13.3, tvOS 16.4, watchOS 9.4
    Android SDK: Not Found
  IDEs:
    Android Studio: 2022.2 AI-222.4459.24.2221.9862592
    Xcode: 14.3.1/14E300c - /usr/bin/xcodebuild
  Languages:
    Java: 11.0.20 - /usr/bin/javac
  npmPackages:
    @react-native-community/cli: Not Found
    react: 18.2.0 => 18.2.0 
    react-native: 0.71.7 => 0.71.7 
    react-native-macos: Not Found
  npmGlobalPackages:
    *react-native*: Not Found
```