### PR TITLE
Upgrade C++ Standard to C++14 for Android Build Compatibility

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.4.1)
 
 set (CMAKE_VERBOSE_MAKEFILE ON)
-set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD 14)
 
 # add directories to "include" search paths
 include_directories(


### PR DESCRIPTION
This change updates the C++ standard version from C++11 to C++14 in the CMakeLists.txt to address compilation issues with `enable_if_t` when building for Android using Expo 50 SDK.

Fixes #62 