### PR TITLE
fix: add prepare script so git dependency installs include the built lib output

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "prepack": "bob build",
+    "prepare": "bob build",
     "release": "release-it",
     "example": "yarn --cwd example",
     "bootstrap": "yarn example && yarn install && yarn example pods",


### PR DESCRIPTION
npm, yarn 1, and pnpm run prepare — but not prepack — for git dependencies, so installing this package from a git URL currently ships no lib/. Metro consumers survive via the "react-native": "src/index" field, but anything resolving main/module/types (plain Node, consumer-side tsc) dangles. This adds "prepare": "bob build" alongside the existing prepack.
Verified: a fresh clone installed with --ignore-scripts has no lib/; yarn prepare produces lib/commonjs, lib/module, lib/typescript; an end-to-end npm install git+file://… consumer receives all three targets, and postinstall still extracts the vendored libsodium. Side effect worth knowing: prepare also runs on local installs in the repo (~4s, devDeps are present) — matching how older react-native-builder-bob templates behaved.
